### PR TITLE
Standalone extensions, bundled extensions, and Core share types

### DIFF
--- a/lib/extension-template.web-view.tsx
+++ b/lib/extension-template.web-view.tsx
@@ -15,7 +15,7 @@ globalThis.webViewComponent = function () {
   const [clicks, setClicks] = useState(0);
 
   const extensionVerseDataProvider = useDataProvider<ExtensionVerseDataProvider>(
-    "paranext-extension-template.quick-verse"
+    "paranextExtensionTemplate.quickVerse"
   );
 
   const [latestExtensionVerseText] = useData.Verse<ExtensionVerseDataTypes, 'Verse'>(
@@ -25,7 +25,7 @@ globalThis.webViewComponent = function () {
   );
 
   const [latestQuickVerseText] = useData.Verse<QuickVerseDataTypes, 'Verse'>(
-    'quick-verse.quick-verse',
+    'quickVerse.quickVerse',
     "latest",
     "Loading latest Scripture text from extension template..."
   );

--- a/lib/extension-template.web-view.tsx
+++ b/lib/extension-template.web-view.tsx
@@ -1,7 +1,8 @@
 import papi from "papi-frontend";
 import { useState } from "react";
-import { QuickVerseDataProvider, QuickVerseDataTypes } from "extension-types";
+import { ExtensionVerseDataProvider, ExtensionVerseDataTypes } from "extension-types";
 import { Button } from "papi-components";
+import { QuickVerseDataTypes } from "papi-extensions/quick-verse/quick-verse";
 
 const {
   react: {
@@ -13,20 +14,27 @@ const {
 globalThis.webViewComponent = function () {
   const [clicks, setClicks] = useState(0);
 
-  const quickVerseDataProvider = useDataProvider<QuickVerseDataProvider>(
+  const extensionVerseDataProvider = useDataProvider<ExtensionVerseDataProvider>(
     "paranext-extension-template.quick-verse"
   );
 
-  const [latestVerseText] = useData.Verse<QuickVerseDataTypes, 'Verse'>(
-    quickVerseDataProvider,
+  const [latestExtensionVerseText] = useData.Verse<ExtensionVerseDataTypes, 'Verse'>(
+    extensionVerseDataProvider,
     "latest",
-    "Loading latest Scripture text..."
+    "Loading latest Scripture text from extension template..."
+  );
+
+  const [latestQuickVerseText] = useData.Verse<QuickVerseDataTypes, 'Verse'>(
+    'quick-verse.quick-verse',
+    "latest",
+    "Loading latest Scripture text from extension template..."
   );
 
   return (
     <>
       <div className="title">Extension Template <span className="framework">React</span></div>
-      <div>{latestVerseText}</div>
+      <div>{latestExtensionVerseText}</div>
+      <div>{latestQuickVerseText}</div>
       <div>
         <Button
           onClick={async () => {

--- a/lib/extension-template.web-view.tsx
+++ b/lib/extension-template.web-view.tsx
@@ -40,12 +40,12 @@ globalThis.webViewComponent = function () {
           onClick={async () => {
             const start = performance.now();
             const result = await papi.commands.sendCommand(
-              "extension-template.do-stuff",
+              "extensionTemplate.doStuff",
               "Extension Template React Component"
             );
             setClicks((currentClicks) => currentClicks + 1);
             logger.info(
-              `command:extension-template.do-stuff '${result}' took ${
+              `command:extensionTemplate.doStuff '${result}' took ${
                 performance.now() - start
               } ms`
             );

--- a/lib/extension-template.web-view.tsx
+++ b/lib/extension-template.web-view.tsx
@@ -1,8 +1,8 @@
 import papi from "papi-frontend";
 import { useState } from "react";
-import { ExtensionVerseDataProvider, ExtensionVerseDataTypes } from "extension-types";
+import { ExtensionVerseDataProvider, ExtensionVerseDataTypes } from "paranext-extension-template";
 import { Button } from "papi-components";
-import { QuickVerseDataTypes } from "papi-extensions/quick-verse/quick-verse";
+import { QuickVerseDataTypes } from "quick-verse";
 
 const {
   react: {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -8,7 +8,7 @@ import extensionTemplateHtml from "./extension-template-html.web-view.ejs";
 import type { SavedWebViewDefinition,
   WebViewContentType,
   WebViewDefinition } from "shared/data/web-view.model";
-import { QuickVerseDataTypes } from "extension-types";
+import { ExtensionVerseDataTypes } from "extension-types";
 import type { DataProviderUpdateInstructions } from "shared/models/data-provider.model";
 import { ExecutionActivationContext } from "extension-host/extension-types/extension-activation-context.model";
 import { ExecutionToken } from "node/models/execution-token.model";
@@ -61,8 +61,8 @@ type QuickVerseSetData = string | { text: string; isHeresy: boolean };
  * define a data provider engine with an object. An example of this is found in `hello-someone.ts`.
  */
 class QuickVerseDataProviderEngine
-  extends DataProviderEngine<QuickVerseDataTypes>
-  implements IDataProviderEngine<QuickVerseDataTypes>
+  extends DataProviderEngine<ExtensionVerseDataTypes>
+  implements IDataProviderEngine<ExtensionVerseDataTypes>
 {
   /**
    * Verses stored by the Data Provider.
@@ -103,7 +103,7 @@ class QuickVerseDataProviderEngine
   async setInternal(
     selector: string,
     data: QuickVerseSetData,
-  ): Promise<DataProviderUpdateInstructions<QuickVerseDataTypes>> {
+  ): Promise<DataProviderUpdateInstructions<ExtensionVerseDataTypes>> {
     // Just get notifications of updates with the 'notify' selector. Nothing to change
     if (selector === 'notify') return false;
 
@@ -334,7 +334,7 @@ export async function activate(context: ExecutionActivationContext) {
   engine.heresyCount = storedHeresyCount;
 
   const quickVerseDataProviderPromise =
-    papi.dataProvider.registerEngine<QuickVerseDataTypes>(
+    papi.dataProvider.registerEngine<ExtensionVerseDataTypes>(
       "paranext-extension-template.quick-verse",
       engine
     );

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -269,7 +269,7 @@ class QuickVerseDataProviderEngine
   }
 }
 
-const htmlWebViewType = "paranext-extension-template.html";
+const htmlWebViewType = "paranextExtensionTemplate.html";
 
 /**
  * Simple web view provider that provides sample html web views when papi requests them
@@ -291,7 +291,7 @@ const htmlWebViewProvider: IWebViewProvider = {
   },
 };
 
-const reactWebViewType = "paranext-extension-template.react";
+const reactWebViewType = "paranextExtensionTemplate.react";
 
 /**
  * Simple web view provider that provides React web views when papi requests them
@@ -335,7 +335,7 @@ export async function activate(context: ExecutionActivationContext) {
 
   const quickVerseDataProviderPromise =
     papi.dataProvider.registerEngine<ExtensionVerseDataTypes>(
-      "paranext-extension-template.quick-verse",
+      "paranextExtensionTemplate.quickVerse",
       engine
     );
 

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -8,7 +8,7 @@ import extensionTemplateHtml from "./extension-template-html.web-view.ejs";
 import type { SavedWebViewDefinition,
   WebViewContentType,
   WebViewDefinition } from "shared/data/web-view.model";
-import { ExtensionVerseDataTypes } from "paranext-extension-template";
+import { ExtensionVerseDataTypes, ExtensionVerseSetData } from "paranext-extension-template";
 import type { DataProviderUpdateInstructions } from "shared/models/data-provider.model";
 import { ExecutionActivationContext } from "extension-host/extension-types/extension-activation-context.model";
 import { ExecutionToken } from "node/models/execution-token.model";
@@ -20,8 +20,6 @@ const { logger, dataProvider: { DataProviderEngine } } = papi;
 console.log(import.meta.env.PROD);
 
 logger.info("Extension template is importing!");
-
-type QuickVerseSetData = string | { text: string; isHeresy: boolean };
 
 /**
  * Example data provider engine that provides easy access to Scripture from an internet API.
@@ -102,7 +100,7 @@ class QuickVerseDataProviderEngine
   @papi.dataProvider.decorators.ignore
   async setInternal(
     selector: string,
-    data: QuickVerseSetData,
+    data: ExtensionVerseSetData,
   ): Promise<DataProviderUpdateInstructions<ExtensionVerseDataTypes>> {
     // Just get notifications of updates with the 'notify' selector. Nothing to change
     if (selector === 'notify') return false;
@@ -140,7 +138,7 @@ class QuickVerseDataProviderEngine
    * Note: this method is used when someone uses the `useData.Verse` hook on the data
    * provider papi creates for this engine.
    */
-  async setVerse(verseRef: string, data: QuickVerseSetData) {
+  async setVerse(verseRef: string, data: ExtensionVerseSetData) {
     return this.setInternal(verseRef, data);
   }
 
@@ -351,7 +349,7 @@ export async function activate(context: ExecutionActivationContext) {
 
   const unsubPromises = [
     papi.commands.registerCommand(
-      "extension-template.do-stuff",
+      "extensionTemplate.doStuff",
       (message: string) => {
         return `The template did stuff! ${message}`;
       }

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -8,7 +8,7 @@ import extensionTemplateHtml from "./extension-template-html.web-view.ejs";
 import type { SavedWebViewDefinition,
   WebViewContentType,
   WebViewDefinition } from "shared/data/web-view.model";
-import { ExtensionVerseDataTypes } from "extension-types";
+import { ExtensionVerseDataTypes } from "paranext-extension-template";
 import type { DataProviderUpdateInstructions } from "shared/models/data-provider.model";
 import { ExecutionActivationContext } from "extension-host/extension-types/extension-activation-context.model";
 import { ExecutionToken } from "node/models/execution-token.model";

--- a/public/assets/index.d.ts
+++ b/public/assets/index.d.ts
@@ -1,0 +1,1 @@
+// This file is here to make tsconfig accept that we want types from `public` without getting angry that we have the `assets` folder that doesn't have or need types

--- a/public/assets/index.d.ts
+++ b/public/assets/index.d.ts
@@ -1,1 +1,4 @@
-// This file is here to make tsconfig accept that we want types from `public` without getting angry that we have the `assets` folder that doesn't have or need types
+// This file is here to make tsconfig accept that we want types from `public` without getting angry
+// that we have the `assets` folder that doesn't have or need types.
+// We can remove it if/when we move `paranext-extension-template.d.ts` to a different place and
+// remove `public` from `typeRoots` in `tsconfig.json`

--- a/public/paranext-extension-template.d.ts
+++ b/public/paranext-extension-template.d.ts
@@ -1,16 +1,19 @@
 import type { DataProviderDataType } from "shared/models/data-provider.model";
 import type IDataProvider from "shared/models/data-provider.interface";
 
-export type ExtensionVerseSetData = string | { text: string; isHeresy: boolean };
+declare module 'paranext-extension-template' {
+  export type ExtensionVerseSetData = string | { text: string; isHeresy: boolean };
+  
+  export type ExtensionVerseDataTypes = {
+    Verse: DataProviderDataType<string, string | undefined, ExtensionVerseSetData>;
+    Heresy: DataProviderDataType<string, string | undefined, string>;
+    Chapter: DataProviderDataType<
+      [book: string, chapter: number],
+      string | undefined,
+      never
+    >;
+  };
+  
+  export type ExtensionVerseDataProvider = IDataProvider<ExtensionVerseDataTypes>;
+}
 
-export type ExtensionVerseDataTypes = {
-  Verse: DataProviderDataType<string, string | undefined, ExtensionVerseSetData>;
-  Heresy: DataProviderDataType<string, string | undefined, string>;
-  Chapter: DataProviderDataType<
-    [book: string, chapter: number],
-    string | undefined,
-    never
-  >;
-};
-
-export type ExtensionVerseDataProvider = IDataProvider<ExtensionVerseDataTypes>;

--- a/public/paranext-extension-template.d.ts
+++ b/public/paranext-extension-template.d.ts
@@ -17,3 +17,9 @@ declare module 'paranext-extension-template' {
   export type ExtensionVerseDataProvider = IDataProvider<ExtensionVerseDataTypes>;
 }
 
+declare module "papi-commands" {
+  export interface CommandHandlers {
+    "extensionTemplate.doStuff": (message: string) => string;
+  }
+}
+

--- a/public/paranext-extension-template.d.ts
+++ b/public/paranext-extension-template.d.ts
@@ -1,10 +1,10 @@
 import type { DataProviderDataType } from "shared/models/data-provider.model";
 import type IDataProvider from "shared/models/data-provider.interface";
 
-export type QuickVerseSetData = string | { text: string; isHeresy: boolean };
+export type ExtensionVerseSetData = string | { text: string; isHeresy: boolean };
 
-export type QuickVerseDataTypes = {
-  Verse: DataProviderDataType<string, string | undefined, QuickVerseSetData>;
+export type ExtensionVerseDataTypes = {
+  Verse: DataProviderDataType<string, string | undefined, ExtensionVerseSetData>;
   Heresy: DataProviderDataType<string, string | undefined, string>;
   Chapter: DataProviderDataType<
     [book: string, chapter: number],
@@ -13,4 +13,4 @@ export type QuickVerseDataTypes = {
   >;
 };
 
-export type QuickVerseDataProvider = IDataProvider<QuickVerseDataTypes>;
+export type ExtensionVerseDataProvider = IDataProvider<ExtensionVerseDataTypes>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,11 +15,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "typeRoots": ["node_modules/@types", "node_modules/papi-dts", "../paranext-core/extensions/dist"],
-    "paths": {
-      "extension-types": ["./public/paranext-extension-template"],
-      "papi-extensions/*": ["../paranext-core/extensions/dist/*"]
-    },
+    "typeRoots": ["node_modules/@types", "../paranext-core/lib", "../paranext-core/extensions/dist", "./public"],
     "experimentalDecorators": true,
   },
   "include": ["lib", "public/paranext-extension-template.d.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "typeRoots": ["node_modules/@types", "../paranext-core/lib", "../paranext-core/extensions/dist", "./public"],
+    "typeRoots": ["node_modules/@types", "../paranext-core/lib", "../paranext-core/extensions/lib", "./public"],
     "experimentalDecorators": true,
   },
   "include": ["lib", "public/paranext-extension-template.d.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,10 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["papi-dts"],
+    "typeRoots": ["node_modules/@types", "node_modules/papi-dts", "../paranext-core/extensions/dist"],
     "paths": {
-      "extension-types": ["./public/paranext-extension-template"]
+      "extension-types": ["./public/paranext-extension-template"],
+      "papi-extensions/*": ["../paranext-core/extensions/dist/*"]
     },
     "experimentalDecorators": true,
   },


### PR DESCRIPTION
- Extensions all can share types via `typeRoots`
- Commands can have their types published with `papi-commands` -> `CommandHandlers`
- Commands now must have at least two strings and a period inbetween
- Recommending lower camel case now instead of kebab case
- Use extensions `lib` folder instead of dist to avoid having to build every time and avoid accidentally changing `dist` `.d.ts` files instead of `lib`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-extension-template/24)
<!-- Reviewable:end -->
