### PR TITLE
feat: added `displayData.json` file for localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ To make the process of customizing from the template as smooth as possible, we r
   - Replace the description with your own description
   - Update ownership information and other relevant fields as desired
 
+- In `contributions/displayData.json`:
+
+  - If your extension has an icon, update the `icon` value to point towards the icon file (for example: `./assets/icon.svg`)
+  - Update the `en` entry so that:
+    
+    - `displayName` contains a human-readable name for your extension (i.e. `Your Extension Name`).
+    - `shortSummary` contains a short, few sentence summary of what your extension does.
+    - `description` points to a Markdown (`.md`) file containing the full description of your extension (similar to what you would put in a `README`).
+  - If your extension supports multiple languages, copy and paste the `en` entry, changing `en` to the [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag) of the language you want to support, and translate the `displayName`, `shortSummary`, and `description` fields appropriately. We recommend naming your description files `description-<language tag>.md`.
+  
 - In `LICENSE`:
 
   - Adjust as desired (feel free to choose a different license)
@@ -72,7 +82,9 @@ The general file structure is as follows:
   - `*.web-view.tsx` files will be treated as React WebViews
   - `*.web-view.html` files are a conventional way to provide HTML WebViews (no special functionality)
 - `assets/` contains asset files the extension and its WebViews can retrieve using the `papi-extension:` protocol. It is copied into the build folder
-- `contributions/` contains JSON files the platform uses to extend data structures for things like menus and settings. The JSON files are referenced from the manifest
+- `contributions/` contains JSON files the platform uses to extend data structures for things like menus, settings, and descriptions. The JSON files are referenced from the manifest
+  - `contributions/displayData.json` contains (optionally) a path to the extension's icon file as well as text for the extension's display name, short summary, and path to the full description file
+  - `contributions/description-<locale>.md` contains a brief description of the extension in the language specified by `<locale>`
 - `public/` contains other static files that are copied into the build folder
 - `dist/` is a generated folder containing the built extension files
 - `release/` is a generated folder containing a zip of the built extension files

--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ To make the process of customizing from the template as smooth as possible, we r
 - In `contributions/displayData.json`:
 
   - If your extension has an icon, update the `icon` value to point towards the icon file (for example: `./assets/icon.svg`)
-  - Update the `en` entry so that:
-    
+  - Update the `en` entry of `localizedDisplayInfo` so that:
+
     - `displayName` contains a human-readable name for your extension (i.e. `Your Extension Name`).
     - `shortSummary` contains a short, few sentence summary of what your extension does.
     - `description` points to a Markdown (`.md`) file containing the full description of your extension (similar to what you would put in a `README`).
-  - If your extension supports multiple languages, copy and paste the `en` entry, changing `en` to the [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag) of the language you want to support, and translate the `displayName`, `shortSummary`, and `description` fields appropriately. We recommend naming your description files `description-<language tag>.md`.
-  
+
+  - If your extension supports multiple languages, add another entry to `localizedDisplayInfo` by copying and pasting the `en` entry, changing `en` to the [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag) of the language you want to support, and translating the `displayName`, `shortSummary`, and `description` fields appropriately. We recommend naming your description files `description-<language tag>.md`.
+
 - In `LICENSE`:
 
   - Adjust as desired (feel free to choose a different license)

--- a/contributions/description-en.md
+++ b/contributions/description-en.md
@@ -1,0 +1,3 @@
+Extension template for Paranext. Powered by webpack.
+
+This is a webpack project template pre-configured to build a Platform.Bible extension. It contains the bare minimum of what an extension needs.

--- a/contributions/displayData.json
+++ b/contributions/displayData.json
@@ -1,8 +1,10 @@
 {
   "icon": "",
-  "en": {
-    "displayName": "Paranext Extension Template",
-    "shortSummary": "Base template for a Paranext Extension",
-    "description": "./description-en.md"
+  "localizedDisplayInfo": {
+    "en": {
+      "displayName": "Paranext Extension Template",
+      "shortSummary": "Base template for a Paranext Extension",
+      "description": "./description-en.md"
+    }
   }
 }

--- a/contributions/displayData.json
+++ b/contributions/displayData.json
@@ -1,0 +1,8 @@
+{
+  "icon": "",
+  "en": {
+    "displayName": "Paranext Extension Template",
+    "shortSummary": "Base template for a Paranext Extension",
+    "description": "./description-en.md"
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "paranext-extension-template",
   "version": "0.0.1",
-  "description": "Extension template for Paranext. Powered by webpack",
+  "displayData": "contributions/displayData.json",
   "author": "Paranext",
   "license": "MIT",
   "main": "src/main.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,11 +66,15 @@
     "../paranext-core/lib/papi-dts": {
       "version": "0.0.1",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "platform-bible-utils": "file:../platform-bible-utils"
+      },
+      "devDependencies": {
         "escape-string-regexp": "^5.0.0",
-        "platform-bible-utils": "file:../platform-bible-utils",
         "rimraf": "^5.0.5",
-        "typescript": "^5.3.3"
+        "typedoc": "^0.25.13",
+        "typescript": "^5.4.5"
       }
     },
     "../paranext-core/lib/papi-dts/node_modules/@isaacs/cliui": {
@@ -554,14 +558,29 @@
     "../paranext-core/lib/platform-bible-react": {
       "version": "0.0.1",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "@emotion/react": ">=11.11.4",
+        "@emotion/styled": ">=11.11.0",
+        "@mui/material": ">=5.15.10",
+        "@radix-ui/react-dropdown-menu": "^2.0.6",
+        "@radix-ui/react-label": "^2.0.2",
+        "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-tabs": "^1.0.4",
+        "autoprefixer": "^10.4.19",
+        "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.0",
+        "lucide-react": "^0.367.0",
+        "platform-bible-utils": "file:../platform-bible-utils",
+        "react-data-grid": ">=7.0.0-beta.34",
+        "tailwind-merge": "^2.2.2",
+        "tailwindcss-animate": "^1.0.7"
+      },
+      "devDependencies": {
         "@babel/preset-env": "^7.24.3",
         "@babel/preset-react": "^7.24.1",
         "@babel/preset-typescript": "^7.24.1",
-        "@emotion/react": ">=11.11.4",
-        "@emotion/styled": ">=11.11.0",
         "@mui/icons-material": "^5.15.10",
-        "@mui/material": ">=5.15.10",
         "@senojs/rollup-plugin-style-inject": "^0.2.3",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.2",
@@ -578,26 +597,39 @@
         "eslint-plugin-prettier": "^5.1.3",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "platform-bible-utils": "file:../platform-bible-utils",
         "prettier": "^3.2.5",
         "prettier-plugin-jsdoc": "^1.3.0",
-        "react-data-grid": ">=7.0.0-beta.34",
+        "prettier-plugin-tailwindcss": "^0.5.14",
         "stylelint": "^16.3.1",
         "stylelint-config-recommended": "^14.0.0",
         "stylelint-config-sass-guidelines": "^11.0.0",
+        "stylelint-config-tailwindcss": "^0.0.7",
+        "tailwindcss": "^3.4.3",
+        "tailwindcss-scoped-preflight": "^2.1.0",
+        "ts-jest": "^29.1.2",
         "tslib": "^2.6.2",
-        "typescript": "^5.3.3",
-        "vite": "^4.5.3"
+        "typedoc": "^0.25.13",
+        "typescript": "^5.4.5",
+        "vite": "^4.5.3",
+        "vite-tsconfig-paths": "^4.3.2"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0"
       }
     },
     "../paranext-core/lib/platform-bible-utils": {
       "version": "0.0.1",
+      "license": "MIT",
       "dependencies": {
+        "async-mutex": "^0.4.1"
+      },
+      "devDependencies": {
         "@types/jest": "^29.5.12",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
-        "async-mutex": "^0.4.1",
         "dts-bundle-generator": "^9.3.1",
+        "escape-string-regexp": "^5.0.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
@@ -606,7 +638,8 @@
         "prettier-plugin-jsdoc": "^1.3.0",
         "stringz": "^2.1.0",
         "tslib": "^2.6.2",
-        "typescript": "^5.3.3",
+        "typedoc": "^0.25.13",
+        "typescript": "^5.4.5",
         "vite": "^4.5.3"
       }
     },
@@ -21489,7 +21522,8 @@
         "escape-string-regexp": "^5.0.0",
         "platform-bible-utils": "file:../platform-bible-utils",
         "rimraf": "^5.0.5",
-        "typescript": "^5.3.3"
+        "typedoc": "^0.25.13",
+        "typescript": "^5.4.5"
       },
       "dependencies": {
         "@isaacs/cliui": {
@@ -21630,6 +21664,7 @@
             "@typescript-eslint/parser": "^6.21.0",
             "async-mutex": "^0.4.1",
             "dts-bundle-generator": "^9.3.1",
+            "escape-string-regexp": "^5.0.0",
             "eslint": "^8.57.0",
             "eslint-config-prettier": "^9.1.0",
             "eslint-plugin-prettier": "^5.1.3",
@@ -21638,7 +21673,8 @@
             "prettier-plugin-jsdoc": "^1.3.0",
             "stringz": "^2.1.0",
             "tslib": "^2.6.2",
-            "typescript": "^5.3.3",
+            "typedoc": "^0.25.13",
+            "typescript": "^5.4.5",
             "vite": "^4.5.3"
           }
         },
@@ -21903,6 +21939,10 @@
         "@emotion/styled": ">=11.11.0",
         "@mui/icons-material": "^5.15.10",
         "@mui/material": ">=5.15.10",
+        "@radix-ui/react-dropdown-menu": "^2.0.6",
+        "@radix-ui/react-label": "^2.0.2",
+        "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-tabs": "^1.0.4",
         "@senojs/rollup-plugin-style-inject": "^0.2.3",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.2",
@@ -21913,22 +21953,35 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "@vitejs/plugin-react": "^4.2.1",
+        "autoprefixer": "^10.4.19",
+        "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.0",
         "dts-bundle-generator": "^9.3.1",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "lucide-react": "^0.367.0",
         "platform-bible-utils": "file:../platform-bible-utils",
         "prettier": "^3.2.5",
         "prettier-plugin-jsdoc": "^1.3.0",
+        "prettier-plugin-tailwindcss": "^0.5.14",
         "react-data-grid": ">=7.0.0-beta.34",
         "stylelint": "^16.3.1",
         "stylelint-config-recommended": "^14.0.0",
         "stylelint-config-sass-guidelines": "^11.0.0",
+        "stylelint-config-tailwindcss": "^0.0.7",
+        "tailwind-merge": "^2.2.2",
+        "tailwindcss": "^3.4.3",
+        "tailwindcss-animate": "^1.0.7",
+        "tailwindcss-scoped-preflight": "^2.1.0",
+        "ts-jest": "^29.1.2",
         "tslib": "^2.6.2",
-        "typescript": "^5.3.3",
-        "vite": "^4.5.3"
+        "typedoc": "^0.25.13",
+        "typescript": "^5.4.5",
+        "vite": "^4.5.3",
+        "vite-tsconfig-paths": "^4.3.2"
       }
     },
     "platform-bible-utils": {
@@ -21939,6 +21992,7 @@
         "@typescript-eslint/parser": "^6.21.0",
         "async-mutex": "^0.4.1",
         "dts-bundle-generator": "^9.3.1",
+        "escape-string-regexp": "^5.0.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
@@ -21947,7 +22001,8 @@
         "prettier-plugin-jsdoc": "^1.3.0",
         "stringz": "^2.1.0",
         "tslib": "^2.6.2",
-        "typescript": "^5.3.3",
+        "typedoc": "^0.25.13",
+        "typescript": "^5.4.5",
         "vite": "^4.5.3"
       }
     },


### PR DESCRIPTION
This PR addresses a [relevant issue](https://github.com/orgs/paranext/projects/4/views/1?pane=issue&itemId=68733795) in `extension-marketplace-services`.

Previously, the `manifest.json` file contained a `description` field for the extension. This PR modifies this template to align with the [Marketplace Spec](https://docs.google.com/document/d/1l8tlXKC8Wxz6RH4bAKMRYmMFkE3-I7YVn608ye2cRqM/edit#heading=h.y1cdjxgum4zu) so that the `manifest.json` contains an entry that points to `displayData.json`. This new file contains localized values for `displayName`, `shortSummary`, and `description`, as well as a path for an extension's icon file.

The `README.md` has been updated to include the steps for replacing the new placeholder values in `Replace placeholders`, as well as a few extra bullets under `Summary` that explain the newly-added files.

As the `displayData.json` file is located under `contributions/`, none of the Webpack settings needed to be modified, as the `contributions` folder is [already copied in its entirety when generating a `.zip` file](https://github.com/paranext/paranext-extension-template/blob/ef6e90c5a89f1e02d0f27bf8aac4b7be2bfc4b7d/webpack/webpack.config.main.ts#L57).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-extension-template/70)
<!-- Reviewable:end -->
