### PR TITLE
Target ES2022 in SWC config to avoid Function polyfill crash

### DIFF
--- a/webpack/webpack.config.base.ts
+++ b/webpack/webpack.config.base.ts
@@ -82,6 +82,13 @@ const configBase: webpack.Configuration = {
                 tsx: true,
                 decorators: true,
               },
+              // Target a modern ES version so SWC emits native `class extends <builtin>` instead of
+              // downleveling it through the `_wrapNativeSuper` helper, which references the global
+              // `Function` constructor. Platform.Bible deletes `globalThis.Function` (and `eval`)
+              // before activating extensions, so that helper throws "Function is not defined" at
+              // load time (e.g. for `class MissingApiKeyError extends Error`). Both runtimes — the
+              // Node extension host and the Chromium WebView — fully support ES2022.
+              target: 'es2022',
             },
           },
         },


### PR DESCRIPTION
## Summary
- Platform.Bible deletes `globalThis.Function` (and `eval`) before activating extensions.
- SWC's downleveled `class extends <builtin>` output uses a `_wrapNativeSuper` helper that references the global `Function` constructor, so any class like `class MissingApiKeyError extends Error` throws `Function is not defined` at load time.
- Both the Node extension host and the Chromium WebView fully support ES2022, so set SWC's `target` to `es2022` to emit native class-extends syntax instead of the polyfilled helper.

Already verified in the PT Assistant extension; this PR just back-ports the fix to the template.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-extension-template/160)
<!-- Reviewable:end -->
